### PR TITLE
Fixed swapchain sync with present.

### DIFF
--- a/src/app/vulkan/DeviceManager_VK.cpp
+++ b/src/app/vulkan/DeviceManager_VK.cpp
@@ -1232,7 +1232,7 @@ void DeviceManager_VK::Present()
     }
 #endif
 
-    while (m_FramesInFlight.size() > m_DeviceParams.maxFramesInFlight)
+    while (m_FramesInFlight.size() >= m_DeviceParams.maxFramesInFlight)
     {
         auto query = m_FramesInFlight.front();
         m_FramesInFlight.pop();


### PR DESCRIPTION
### Proper present handling with multiple frames in flight
Usage of m_PresentQueue.waitIdle(); with enabled validation layers (m_DeviceParams.enableDebugRuntime) shadows validation errors due to incorrect swapchain handling over frames. For example, overriding Validation Layers for release builds via Vulkan Configurator without enabling debug runtime internally, to prevent unnecessary waitIdle() calls in present queue, leads to constant validation errors:

> VUID-vkAcquireNextImageKHR-semaphore-01779(ERROR / SPEC): msgNum: 1461184347 - Validation Error: [ VUID-vkAcquireNextImageKHR-semaphore-01779 ] Object 0: handle = 0xee647e0000000009, type = VK_OBJECT_TYPE_SEMAPHORE; | MessageID = 0x5717e75b | vkAcquireNextImageKHR():  Semaphore must not have any pending operations. The Vulkan spec states: If semaphore is not VK_NULL_HANDLE it must not have any uncompleted signal or wait operations pending (https://vulkan.lunarg.com/doc/view/1.3.275.0/windows/1.3-extensions/vkspec.html#VUID-vkAcquireNextImageKHR-semaphore-01779)
>     Objects: 1
>         [0] 0xee647e0000000009, type: 5, name: NULL

Thus, using only one semaphore for handling multiple "frames-in-flight" is not enough. Each "frame-in-flight" must have its own semaphore at least. 
Best way is to create 'm_DeviceParams.maxFramesInFlight + 1' semaphores and use them for each "frame-in-flight".

---

### No need to wait idle in present queue
With debug runtime enabled calls like m_PresentQueue.waitIdle() aren't needed at all. Information on vulkan-tutorial.com already changed and validation layers are doing well.
This change also **boost perfomance in DEBUG builds**. For example: 'rt_bindless' example from 'donut_examples' runs in debug **without** this changes at around 200 FPS and at around 300 FPS **with** this changes on NVIDIA RTX 3060 Laptop GPU. 