### PR TITLE
remove index access on unordered_map inside class ResourceTracker

### DIFF
--- a/include/donut/engine/SceneGraph.h
+++ b/include/donut/engine/SceneGraph.h
@@ -511,7 +511,6 @@ namespace donut::engine
         [[nodiscard]] ConstIterator end() const { return ConstIterator(m_Map.cend()); }
         [[nodiscard]] bool empty() const { return m_Map.empty(); }
         [[nodiscard]] size_t size() const { return m_Map.size(); }
-        [[nodiscard]] const std::shared_ptr<T>& operator[](size_t i) { return m_Map[i].first; }
     };
 
     template<typename T>


### PR DESCRIPTION
`std::unordered_map<T>` only supports `operator [](T&&)`.
It's an unordered container, so index access doesn't make sense.
Actually, no code use the function and if anyone tries, it won't compile in any meaningful case