### PR TITLE
Fix computing frustum for stereo view

### DIFF
--- a/include/donut/engine/View.h
+++ b/include/donut/engine/View.h
@@ -235,7 +235,7 @@ namespace donut::engine
         [[nodiscard]] dm::frustum GetViewFrustum() const override
         {
             dm::frustum left = LeftView.GetViewFrustum();
-            dm::frustum right = LeftView.GetViewFrustum();
+            dm::frustum right = RightView.GetViewFrustum();
 
             // not robust but should work for regular stereo views
             left.planes[dm::frustum::RIGHT_PLANE] = right.planes[dm::frustum::RIGHT_PLANE];


### PR DESCRIPTION
The function was using 2 left view frustum for computing the overall frustum for the stereo view frustum instead of both the left and the right one