### PR TITLE
Fix the calculation of jointStride and weightStride of GLTF-Importer…

### DIFF
--- a/src/engine/GltfImporter.cpp
+++ b/src/engine/GltfImporter.cpp
@@ -802,6 +802,9 @@ bool GltfImporter::Load(
 
                 if (joint_indices->component_type == cgltf_component_type_r_8u)
                 {
+
+                    if (!jointStride) jointStride = sizeof(uint8_t) * 4;
+
                     for (size_t v_idx = 0; v_idx < joint_indices->count; v_idx++)
                     {
                         *jointDst = dm::vector<uint16_t, 4>(jointSrc[0], jointSrc[1], jointSrc[2], jointSrc[3]);
@@ -813,6 +816,9 @@ bool GltfImporter::Load(
                 else
                 {
                     assert(joint_indices->component_type == cgltf_component_type_r_16u);
+
+                    if (!jointStride) jointStride = sizeof(uint16_t) * 4;
+
                     for (size_t v_idx = 0; v_idx < joint_indices->count; v_idx++)
                     {
                         const uint16_t* jointSrcUshort = (const uint16_t*)jointSrc;
@@ -833,6 +839,9 @@ bool GltfImporter::Load(
 
                 if (joint_weights->component_type == cgltf_component_type_r_8u)
                 {
+
+                    if (!weightStride) weightStride = sizeof(uint8_t) * 4;
+
                     for (size_t v_idx = 0; v_idx < joint_indices->count; v_idx++)
                     {
                         *weightDst = dm::float4(
@@ -847,6 +856,8 @@ bool GltfImporter::Load(
                 }
                 else if (joint_weights->component_type == cgltf_component_type_r_16u)
                 {
+                    if (!weightStride) weightStride = sizeof(uint16_t) * 4;
+
                     for (size_t v_idx = 0; v_idx < joint_indices->count; v_idx++)
                     {
                         const uint16_t* weightSrcUshort = (const uint16_t*)weightSrc;
@@ -863,6 +874,9 @@ bool GltfImporter::Load(
                 else
                 {
                     assert(joint_weights->component_type == cgltf_component_type_r_32f);
+
+                    if (!weightStride) weightStride = sizeof(float) * 4;
+
                     for (size_t v_idx = 0; v_idx < joint_indices->count; v_idx++)
                     {
                         *weightDst = (const float*)weightSrc;


### PR DESCRIPTION
When I load one [GLTF](https://github.com/HanetakaChou/glTF-Assets/tree/sparkle) asset, the **jointStride** and **weightStride** can be **zero**!

We should change the stride manually, just like how we calcualte the **indexStride** when importing the **IndexBuffer**.

```cpp
            if (joint_indices)
            {
                assert(joint_indices->count == positions->count);

                auto [jointSrc, jointStride] = cgltf_buffer_iterator(joint_indices, 0);
                vector<uint16_t, 4>* jointDst = buffers->jointData.data() + totalVertices;

                if (joint_indices->component_type == cgltf_component_type_r_8u)
                {
                    // !!! This line is what I add.
                    if (!jointStride) jointStride = sizeof(uint8_t) * 4;

                    for (size_t v_idx = 0; v_idx < joint_indices->count; v_idx++)
                    {
                        *jointDst = dm::vector<uint16_t, 4>(jointSrc[0], jointSrc[1], jointSrc[2], jointSrc[3]);

                        jointSrc += jointStride;
                        ++jointDst;
                    }
                }
                else
                {
                    assert(joint_indices->component_type == cgltf_component_type_r_16u);

                    // !!! This line is what I add.
                    if (!jointStride) jointStride = sizeof(uint16_t) * 4;

                    for (size_t v_idx = 0; v_idx < joint_indices->count; v_idx++)
                    {
                        const uint16_t* jointSrcUshort = (const uint16_t*)jointSrc;
                        *jointDst = dm::vector<uint16_t, 4>(jointSrcUshort[0], jointSrcUshort[1], jointSrcUshort[2], jointSrcUshort[3]);

                        jointSrc += jointStride;
                        ++jointDst;
                    }
                }
            }

            if (joint_weights)
            {
                assert(joint_weights->count == positions->count);

                auto [weightSrc, weightStride] = cgltf_buffer_iterator(joint_weights, 0);
                float4* weightDst = buffers->weightData.data() + totalVertices;

                if (joint_weights->component_type == cgltf_component_type_r_8u)
                {

                    // !!! This line is what I add.
                    if (!weightStride) weightStride = sizeof(uint8_t) * 4;

                    for (size_t v_idx = 0; v_idx < joint_indices->count; v_idx++)
                    {
                        *weightDst = dm::float4(
                            float(weightSrc[0]) / 255.f,
                            float(weightSrc[1]) / 255.f,
                            float(weightSrc[2]) / 255.f,
                            float(weightSrc[3]) / 255.f);

                        weightSrc += weightStride;
                        ++weightDst;
                    }
                }
                else if (joint_weights->component_type == cgltf_component_type_r_16u)
                {

                    // !!! This line is what I add.
                    if (!weightStride) weightStride = sizeof(uint16_t) * 4;

                    for (size_t v_idx = 0; v_idx < joint_indices->count; v_idx++)
                    {
                        const uint16_t* weightSrcUshort = (const uint16_t*)weightSrc;
                        *weightDst = dm::float4(
                            float(weightSrcUshort[0]) / 65535.f,
                            float(weightSrcUshort[1]) / 65535.f,
                            float(weightSrcUshort[2]) / 65535.f,
                            float(weightSrcUshort[3]) / 65535.f);
                        
                        weightSrc += weightStride;
                        ++weightDst;
                    }
                }
                else
                {
                    assert(joint_weights->component_type == cgltf_component_type_r_32f);

                    // !!! This line is what I add.
                    if (!weightStride) weightStride = sizeof(float) * 4;

                    for (size_t v_idx = 0; v_idx < joint_indices->count; v_idx++)
                    {
                        *weightDst = (const float*)weightSrc;

                        weightSrc += weightStride;
                        ++weightDst;
                    }
                }
            }
```