### PR TITLE
Fix the missing index buffer offset for skinned mesh instance.

### DIFF
--- a/src/engine/SceneGraph.cpp
+++ b/src/engine/SceneGraph.cpp
@@ -56,6 +56,7 @@ SkinnedMeshInstance::SkinnedMeshInstance(std::shared_ptr<SceneTypeFactory> scene
     skinnedMesh->skinPrototype = m_PrototypeMesh;
     skinnedMesh->name = m_PrototypeMesh->name;
     skinnedMesh->objectSpaceBounds = m_PrototypeMesh->objectSpaceBounds;
+    skinnedMesh->indexOffset = m_PrototypeMesh->indexOffset;
     skinnedMesh->totalVertices = m_PrototypeMesh->totalVertices;
     skinnedMesh->totalIndices = m_PrototypeMesh->totalIndices;
     skinnedMesh->geometries.reserve(m_PrototypeMesh->geometries.size());


### PR DESCRIPTION

```cpp
 // ...

 for (const auto& skinnedInstance : m_SceneGraph->GetSkinnedMeshInstances())
    {
        const auto& skinnedMesh = skinnedInstance->GetMesh();

        if (!skinnedMesh->buffers)
        {
            skinnedMesh->buffers = std::make_shared<BufferGroup>();

            uint32_t totalVertices = skinnedMesh->totalVertices;

            skinnedMesh->buffers->indexBuffer = skinnedInstance->GetPrototypeMesh()->buffers->indexBuffer;
            skinnedMesh->buffers->indexBufferDescriptor = skinnedInstance->GetPrototypeMesh()->buffers->indexBufferDescriptor;

 // ...
```
According to the above code within [Scene::CreateMeshBuffers](https://github.com/NVIDIAGameWorks/donut/blob/main/src/engine/Scene.cpp#L1018), the same index buffer may be shared by different skinned meshes.  

Thus, the **index offset** should NOT be omitted when creating the skinned mesh.