### PR TITLE
Allow for mesh instances without geometry

### DIFF
--- a/src/engine/Scene.cpp
+++ b/src/engine/Scene.cpp
@@ -936,6 +936,11 @@ void Scene::CreateMeshBuffers(nvrhi::ICommandList* commandList)
                     buffers->radiusData.size() * sizeof(buffers->radiusData[0]), bufferDesc.byteSize);
             }
 
+            if (bufferDesc.byteSize == 0)
+            {
+	            continue;
+            }
+
             buffers->vertexBuffer = m_Device->createBuffer(bufferDesc);
             if (m_DescriptorTable)
             {
@@ -1235,8 +1240,8 @@ void Scene::UpdateInstance(const std::shared_ptr<MeshInstance>& instance)
 
     const auto& mesh = instance->GetMesh();
     idata.firstGeometryInstanceIndex = instance->GetGeometryInstanceIndex();
-    idata.firstGeometryIndex = mesh->geometries[0]->globalGeometryIndex;
     idata.numGeometries = uint32_t(mesh->geometries.size());
+    idata.firstGeometryIndex = idata.numGeometries > 0 ? mesh->geometries[0]->globalGeometryIndex : -1;
     idata.flags = 0u;
 
     if (mesh->type == MeshType::CurveDisjointOrthogonalTriangleStrips)


### PR DESCRIPTION
This PR makes small modifications to `donut::engine::Scene` that avoids fatal crashes when a `MeshInfo` does not have any vertex data or geometries. This does not change existing behaviour for meshes that do have geometries or vertex data.

The motivation for this in my situation is to be able to create procedural geometry where all geometry is created within the vertex shader, which is dispatched using `drawIndirect`, thus no vertex or index buffers. Inheriting from `MeshInfo` and `MeshInstance` allows for convenient integration of procedural meshes with the existing Scene and Scene Graph systems, including automatic population of the `Scene`'s instance buffer etc without having to re-implement most of `Scene`'s functionality.