### PR TITLE
Custom scene graph types

### DIFF
--- a/include/donut/engine/Scene.h
+++ b/include/donut/engine/Scene.h
@@ -110,7 +110,7 @@ namespace donut::engine
         virtual nvrhi::BufferHandle CreateInstanceBuffer();
         virtual nvrhi::BufferHandle CreateMaterialConstantBuffer(const std::string& debugName);
 
-        virtual bool LoadCustomData(Json::Value& rootNode, tf::Executor* executor);
+        virtual bool LoadCustomData(Json::Value& rootNode, const std::filesystem::path& scenePath, tf::Executor* executor);
     public:
         virtual ~Scene() = default;
 

--- a/include/donut/engine/SceneGraph.h
+++ b/include/donut/engine/SceneGraph.h
@@ -591,6 +591,7 @@ namespace donut::engine
     {
     public:
         virtual ~SceneTypeFactory() = default;
+        virtual std::shared_ptr<SceneGraph> CreateGraph();
         virtual std::shared_ptr<SceneGraphLeaf> CreateLeaf(const std::string& type);
         virtual std::shared_ptr<Material> CreateMaterial();
         virtual std::shared_ptr<MeshInfo> CreateMesh();

--- a/src/engine/Scene.cpp
+++ b/src/engine/Scene.cpp
@@ -181,7 +181,7 @@ bool Scene::LoadWithExecutor(const std::filesystem::path& sceneFileName, tf::Exe
 
         if (documentRoot.isObject())
         {
-            if (!LoadCustomData(documentRoot, executor))
+            if (!LoadCustomData(documentRoot, scenePath, executor))
                 return false;
 
             LoadModels(documentRoot["models"], scenePath, executor);
@@ -592,7 +592,7 @@ void Scene::LoadAnimations(const Json::Value& nodeList)
     }
 }
 
-bool Scene::LoadCustomData(Json::Value& rootNode, tf::Executor* executor)
+bool Scene::LoadCustomData(Json::Value& rootNode, const std::filesystem::path& scenePath, tf::Executor* executor)
 {
     // Reserved for derived classes
     return true;

--- a/src/engine/Scene.cpp
+++ b/src/engine/Scene.cpp
@@ -148,7 +148,7 @@ bool Scene::LoadWithExecutor(const std::filesystem::path& sceneFileName, tf::Exe
     g_LoadingStats.ObjectsLoaded = 0;
     g_LoadingStats.ObjectsTotal = 0;
     
-    m_SceneGraph = std::make_shared<SceneGraph>();
+    m_SceneGraph = m_SceneTypeFactory->CreateGraph();
 
     if (sceneFileName.extension() == ".gltf" || sceneFileName.extension() == ".glb")
     {

--- a/src/engine/SceneGraph.cpp
+++ b/src/engine/SceneGraph.cpp
@@ -1134,6 +1134,11 @@ void SceneGraph::Refresh(uint32_t frameIndex)
     }
 }
 
+std::shared_ptr<SceneGraph> SceneTypeFactory::CreateGraph()
+{
+	return std::make_shared<SceneGraph>();
+}
+
 std::shared_ptr<SceneGraphLeaf> SceneTypeFactory::CreateLeaf(const std::string& type)
 {
     if (type == "DirectionalLight")


### PR DESCRIPTION
This pull request makes two small changes to make it easier to work with custom scene types:
1. Added `SceneTypeFactory::CreateGraph`, a factory method that makes it easy to supply a scene graph of a derived type. This is used in `Scene::LoadWithExecutor` to avoid having to override the loader simply to use a derived scene graph type. For anyone not interested in deriving from `SceneGraph`, no code changes are required.
2. Added the path to the scene file as a function parameter to `LoadCustomData`. This is useful if the custom data in the scene file specifies paths to resources relative to the scene file itself. This will require code changes for clients of `LoadCustomData` but nevertheless I think it would be useful.