### PR TITLE
Added user data field to draw item

### DIFF
--- a/include/donut/render/GeometryPasses.h
+++ b/include/donut/render/GeometryPasses.h
@@ -49,6 +49,7 @@ namespace donut::render
         const engine::BufferGroup* buffers;
         float distanceToCamera;
         nvrhi::RasterCullMode cullMode;
+        void* userData;
     };
 
     class GeometryPassContext

--- a/src/render/DrawStrategy.cpp
+++ b/src/render/DrawStrategy.cpp
@@ -114,6 +114,7 @@ void InstancedOpaqueDrawStrategy::FillChunk()
                         item.buffers = item.mesh->buffers.get();
                         item.cullMode = (item.material->doubleSided) ? nvrhi::RasterCullMode::None : nvrhi::RasterCullMode::Back;
                         item.distanceToCamera = 0; // don't care
+                        item.userData = nullptr;
                         
                         ++writePtr;
                         ++itemCount;
@@ -222,6 +223,7 @@ void TransparentDrawStrategy::PrepareForView(const std::shared_ptr<engine::Scene
                         item.material = geometry->material.get();
                         item.buffers = mesh->buffers.get();
                         item.distanceToCamera = length(geometryGlobalBoundingBox.center() - viewOrigin);
+                        item.userData = nullptr;
                         if (material->doubleSided)
                         {
                             if (DrawDoubleSidedMaterialsSeparately)


### PR DESCRIPTION
Allows extension of the `donut::render::DrawItem` structure via a user data `void*`.

My use case for this is I have a mesh instance with multiple representations, and I want to select the representation I use in the draw strategy. The render pass can then recover the desired representation from the draw item keeping the scene and renderer decoupled. However, without DrawItem being polymorphic, there is no safe way to extend DrawItem in my code via inheritance. 

I saw packaging user data inside a `void*` to be a more general purpose solution and imagine it could be generally useful to implementations of more complex render passes or scene content that still want to make use of the draw strategy interface.