### PR TITLE
Template function fixes and left-handedness consistency

### DIFF
--- a/include/donut/core/math/box.h
+++ b/include/donut/core/math/box.h
@@ -251,25 +251,25 @@ namespace donut::math
 	template <typename T, int n>
 	T distance(box<T, n> const & a, vector<T, n> const & b)
 	{
-		return distance(a.clamp(b), b);
+		return length(a.clamp(b) - b);
 	}
 
 	template <typename T, int n>
 	T distance(vector<T, n> const & a, box<T, n> const & b)
 	{
-		return distance(a, b.clamp(a));
+		return length(a - b.clamp(a));
 	}
 
 	template <typename T, int n>
 	T distanceSquared(box<T, n> const & a, vector<T, n> const & b)
 	{
-		return distanceSquared(a.clamp(b), b);
+		return lengthSquared(a.clamp(b) - b);
 	}
 
 	template <typename T, int n>
 	T distanceSquared(vector<T, n> const & a, box<T, n> const & b)
 	{
-		return distanceSquared(a, b.clamp(a));
+		return lengthSquared(a - b.clamp(a));
 	}
 
 	// !!! this doesn't match the behavior of isnear() for vectors and matrices -

--- a/include/donut/core/math/box.h
+++ b/include/donut/core/math/box.h
@@ -214,7 +214,7 @@ namespace donut::math
             return result;
         }
 
-        box operator *= (const affine<T, n>& transform) const
+        box operator *= (const affine<T, n>& transform)
         {
             *this = *this * transform;
             return *this;

--- a/include/donut/core/math/quat.h
+++ b/include/donut/core/math/quat.h
@@ -392,7 +392,7 @@ namespace donut::math
 		T sinHalfTheta = std::sin(T(0.5) * radians);
 		T cosHalfTheta = std::cos(T(0.5) * radians);
 
-		return quaternion<T>(cosHalfTheta, axis * sinHalfTheta);
+		return quaternion<T>::fromWXYZ(cosHalfTheta, axis * sinHalfTheta);
 	}
 
 	template<typename T>

--- a/include/donut/core/math/vector.h
+++ b/include/donut/core/math/vector.h
@@ -300,6 +300,14 @@ namespace donut::math
 	T length(vector<T, n> const & a)
 		{ return sqrt(lengthSquared(a)); }
 
+    template <typename T, int n>
+	T distanceSquared(vector<T, n> const & a, vector<T, n> const & b)
+		{ return lengthSquared(a-b); }
+
+    template <typename T, int n>
+	T distance(vector<T, n> const & a, vector<T, n> const & b)
+		{ return length(a-b); }
+
 	template <typename T, int n>
 	vector<T, n> normalize(vector<T, n> const & a)
 		{ return a / length(a); }

--- a/include/donut/core/math/vector.h
+++ b/include/donut/core/math/vector.h
@@ -300,14 +300,6 @@ namespace donut::math
 	T length(vector<T, n> const & a)
 		{ return sqrt(lengthSquared(a)); }
 
-    template <typename T, int n>
-	T distanceSquared(vector<T, n> const & a, vector<T, n> const & b)
-		{ return lengthSquared(a-b); }
-
-    template <typename T, int n>
-	T distance(vector<T, n> const & a, vector<T, n> const & b)
-		{ return length(a-b); }
-
 	template <typename T, int n>
 	vector<T, n> normalize(vector<T, n> const & a)
 		{ return a / length(a); }

--- a/include/donut/engine/View.h
+++ b/include/donut/engine/View.h
@@ -90,6 +90,7 @@ namespace donut::engine
         // Directly settable parameters
         nvrhi::Viewport m_Viewport;
         nvrhi::Rect m_ScissorRect;
+        float m_AspectRatio;
         nvrhi::VariableRateShadingState m_ShadingRateState;
         dm::affine3 m_ViewMatrix = dm::affine3::identity();
         dm::float4x4 m_ProjMatrix = dm::float4x4::identity();
@@ -125,6 +126,7 @@ namespace donut::engine
 
         [[nodiscard]] const nvrhi::Viewport& GetViewport() const { return m_Viewport; }
         [[nodiscard]] const nvrhi::Rect& GetScissorRect() const { return m_ScissorRect; }
+        [[nodiscard]] const float GetAspectRatio() const { return m_AspectRatio; }
 
         [[nodiscard]] nvrhi::ViewportState GetViewportState() const override;
         [[nodiscard]] nvrhi::VariableRateShadingState GetVariableRateShadingState() const override;

--- a/include/donut/engine/View.h
+++ b/include/donut/engine/View.h
@@ -117,6 +117,8 @@ namespace donut::engine
         void SetViewport(const nvrhi::Viewport& viewport);
         void SetVariableRateShadingState(const nvrhi::VariableRateShadingState& shadingRateState);
         void SetMatrices(const dm::affine3& viewMatrix, const dm::float4x4& projMatrix);
+        void SetViewMatrix(const dm::affine3& viewMatrix);
+        void SetProjectionMatrix(const dm::float4x4& projMatrix);
         void SetPixelOffset(dm::float2 offset);
         void SetArraySlice(int arraySlice);
         void UpdateCache();

--- a/src/app/Camera.cpp
+++ b/src/app/Camera.cpp
@@ -39,8 +39,8 @@ void BaseCamera::BaseLookAt(float3 cameraPos, float3 cameraTarget, float3 camera
     this->m_CameraPos = cameraPos;
     this->m_CameraDir = normalize(cameraTarget - cameraPos);
     this->m_CameraUp = normalize(cameraUp);
-    this->m_CameraRight = normalize(cross(this->m_CameraDir, this->m_CameraUp));
-    this->m_CameraUp = normalize(cross(this->m_CameraRight, this->m_CameraDir));
+    this->m_CameraRight = normalize(cross(this->m_CameraUp, this->m_CameraDir));
+    this->m_CameraUp = normalize(cross(this->m_CameraDir, this->m_CameraRight));
 
     UpdateWorldToView();
 }
@@ -156,7 +156,7 @@ void FirstPersonCamera::UpdateCamera(dm::float3 cameraMoveVec, dm::affine3 camer
     m_CameraPos += cameraMoveVec;
     m_CameraDir = normalize(cameraRotation.transformVector(m_CameraDir));
     m_CameraUp = normalize(cameraRotation.transformVector(m_CameraUp));
-    m_CameraRight = normalize(cross(m_CameraDir, m_CameraUp));
+    m_CameraRight = normalize(cross(m_CameraUp, m_CameraDir));
 
     UpdateWorldToView();
 }
@@ -205,8 +205,8 @@ void FirstPersonCamera::Animate(float deltaT)
         float yaw = m_RotateSpeed * mouseMove.x;
         float pitch = m_RotateSpeed * mouseMove.y;
 
-        cameraRotation = rotation(float3(0.f, 1.f, 0.f), -yaw);
-        cameraRotation = rotation(m_CameraRight, -pitch) * cameraRotation;
+        cameraRotation = rotation(float3(0.f, 1.f, 0.f), yaw);
+        cameraRotation = rotation(m_CameraRight, pitch) * cameraRotation;
 
         cameraDirty = true;
     }

--- a/src/engine/View.cpp
+++ b/src/engine/View.cpp
@@ -96,6 +96,7 @@ void PlanarView::SetViewport(const nvrhi::Viewport& viewport)
 {
     m_Viewport = viewport;
     m_ScissorRect = nvrhi::Rect(viewport);
+    m_AspectRatio = viewport.width() / viewport.height();
     m_CacheValid = false;
 }
 

--- a/src/engine/View.cpp
+++ b/src/engine/View.cpp
@@ -106,7 +106,18 @@ void PlanarView::SetVariableRateShadingState(const nvrhi::VariableRateShadingSta
 
 void PlanarView::SetMatrices(const affine3& viewMatrix, const float4x4& projMatrix)
 {
+    SetViewMatrix(viewMatrix);
+    SetProjectionMatrix(projMatrix);
+}
+
+void PlanarView::SetViewMatrix(const affine3& viewMatrix)
+{
     m_ViewMatrix = viewMatrix;
+    m_CacheValid = false;
+}
+
+void PlanarView::SetProjectionMatrix(const float4x4& projMatrix)
+{
     m_ProjMatrix = projMatrix;
     m_CacheValid = false;
 }


### PR DESCRIPTION
- `rotationQuat` in `quat.h` used an undefined constructor, template was edited to use the `fromWXYZ` function instead
- `distance` and `distanceSquared` defined in `vector.h`. `dm::box3::distance` calls `dm::float3::distance` but template is not defined for vector. `dm::box3::distance` now calls `dm::float3::length` instead
- `dm::box3::operator*=` has a const qualifier even though *= is modifying the internals, and is now removed
- created separate projection matrix and view matrix setters so that application does not have to rewrite both if only one needs to get updated. Useful for example where projection matrix stays constant between frames (unless window size changes).
- FirstPersonCamera now updates its basis vectors in accordance with a left-handed coordinate system. Fixes a bug where calling `FirstPersonCamera::LookTo` in application would flicker camera when updating position or direction of camera with keyboard/mouse because the wrong basis vectors are updated with translation and roll/pitch/yaw